### PR TITLE
Improve resiliance to Sonarr connection issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# <img width="24px" src="./img/sonarrToRSS.png" alt="Sonarr To RSS"></img> Sonarr To RSS
+# <img width="24px" src="./img/sonarrToRSS.png" alt="Sonarr to RSS"></img> Sonarr to RSS
 
-Sonarr To RSS is a [Sonarr](https://sonarr.tv/ "Sonarr") Webhook connection endpoint that streams
+Sonarr to RSS is a [Sonarr](https://sonarr.tv/ "Sonarr") Webhook connection endpoint that streams
 events to RSS/Atom/JSON feeds and provides a paginated website to browse historical events.
 
 #### Light mode
@@ -62,7 +62,7 @@ Webhook Connection to send events to `http://localhost:18989/sonarr`. RSS feed i
 ### Authentication
 
 Sonarr to RSS requires authentication for both the browser interface and the Sonarr webhook
-endpoint. Feed endpoints are not authenticated and there is now way to enable this.
+endpoint. Feed endpoints are not authenticated and there is no way to enable this.
 
 #### Local Access
 

--- a/src/express/routes/browse.ts
+++ b/src/express/routes/browse.ts
@@ -22,8 +22,8 @@ export default function (state: State) {
   });
 
   // get series banner image
-  router.get('/banner/:seriesId', (req: Request, res: Response ) => {
-    if (!state.sonarrApi) {
+  router.get('/banner/:seriesId', async (req: Request, res: Response ) => {
+    if (!await state.ensureSonarrApi()) {
       res.statusCode = 500;
       res.end();
       return;


### PR DESCRIPTION
If Sonarr is not connectable at startup, or becomes unconnectable, then Sonarr to RSS was unable to reconnect to fetch series data and banner images once Sonarr became available again.

This situation could easily be encountered in Docker setups where both Sonarr and Sonarr to RSS are running on the same machine. Sonarr to RSS will startup much faster than Sonarr so if both containers are automatically started on system boot Sonarr will not be connectable and the api never becomes available.

All code paths that make calls to Sonarr now make an ensure call to re-initialise the api if it is unavailable. They also clean up correctly on failure so that future calls will be remade.

Fixed typo and name styling in README.md.